### PR TITLE
fix: handle poorly design packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npx ng16-dep-audit
 - **`--style=<style>`**: Specifies the output style. Available styles are `line` (default), `table`, and `markdown`.
 - **`--output=<file>`**: Specifies the file to write the output to. If not provided, output will be displayed in the console.
 - **`--skip-ng (-ng)`**: This will skip over all angular internal packages
+- **`--package-boundary (-pb)`**: ensure @angular/core is included in library package.json.
 
 ### Examples
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const args = process.argv.slice(2);
 const helpArg = args.find(arg => arg === '-h' || arg === '--help');
 const versionArg = args.find(arg => arg === '-v' || arg === '--version');
 const skipAngular = args.find(arg => arg === '-ng' || arg === '--skip-ng');
+const enforceAngularPackageBoundary = args.find(arg => arg === '-pb' || arg === '--package-boundary') || false;
 const outputArg = args.find(arg => arg.startsWith('--output='));
 const outputFile = outputArg ? outputArg.split('=')[1] : null;
 const styleArg = args.find(arg => arg.startsWith('--style='));
@@ -41,9 +42,9 @@ function displayHelp() {
   console.log(colorize('  -h, --help', 'green') + colorize('            Output usage information', 'reset'));
   console.log(colorize('  -v, --version', 'green') + colorize('         Output the version number', 'reset'));
   console.log(colorize('  -ng, --skip-ng', 'green') + colorize('        Ignore angular packages in output', 'reset'));
+  console.log(colorize('  -pb, --package-boundary', 'green') + colorize(' ensure @angular/core is included in library package.json', 'reset'));
   console.log(colorize('  --output=<file>', 'green') + colorize('       Specify the output file', 'reset'));
   console.log(colorize('  --style=<style>', 'green') + colorize('       Specify the output style (line, table, markdown)', 'reset') + '\n');
-
 
   console.log(colorize('Examples:', 'yellow', 'bold'));
   console.log(colorize('  npx ng16-dep-audit --style=table', 'cyan'));
@@ -218,10 +219,9 @@ async function checkAngularCompatibility(
       ...packageInfo.peerDependencies,
     };
     const hasAngularCoreDependency = "@angular/core" in allDependencies;
-    if (hasAngularCoreDependency) {
-      const angularCoreVersion = allDependencies["@angular/core"];
+    if ((enforceAngularPackageBoundary && hasAngularCoreDependency) || !enforceAngularPackageBoundary) {
       if (
-        angularCoreVersion && await isViewEngine(packageInfo)
+        await isViewEngine(packageInfo)
       ) {
         dependenciesToCheck.reviewForRemoval.push({
           packageName,


### PR DESCRIPTION
Packages like ngx-echarts and ng-multiselect-dropdown doesnt have @angular in dependencies or peer dependencies. Really it should always be in peer but due to poor standard of node modules we need to handle these packages which mean checks will take longer by default unless using the new --package-boundary/-pb flag